### PR TITLE
Add Visualization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.10.0'
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.10.0'
     implementation 'com.opencsv:opencsv:5.8'
+    implementation group: 'org.knowm.xchart', name: 'xchart', version: '3.8.8'
 }
 
 test {

--- a/src/main/java/wheresmymoney/ExpenseFilter.java
+++ b/src/main/java/wheresmymoney/ExpenseFilter.java
@@ -24,6 +24,7 @@ public class ExpenseFilter {
      * Check if an expense is a match with the given filter criteria
      * If a criteria is null, that field is considered a match
      *
+     * @author andrewnguyen4
      * @param expense the expense under check
      * @param category The filter category
      * @param startDate Expense's dateAdded must not be before this date
@@ -34,7 +35,7 @@ public class ExpenseFilter {
 
     public static boolean isFiltered(Expense expense, String category, String startDate, String endDate)
             throws WheresMyMoneyException {
-        if (category != null && !expense.getCategory().equals(category)) {
+        if (category != null && !isInCategory(expense, category)) {
             return false;
         }
         if (startDate != null && !isAfterStartDate(expense, DateUtils.stringToDate(startDate))) {

--- a/src/main/java/wheresmymoney/Parser.java
+++ b/src/main/java/wheresmymoney/Parser.java
@@ -8,10 +8,11 @@ import wheresmymoney.command.DeleteCommand;
 import wheresmymoney.command.EditCommand;
 import wheresmymoney.command.HelpCommand;
 import wheresmymoney.command.ListCommand;
-import wheresmymoney.command.StatsCommand;
 import wheresmymoney.command.LoadCommand;
 import wheresmymoney.command.SaveCommand;
 import wheresmymoney.command.SetCommand;
+import wheresmymoney.command.StatsCommand;
+import wheresmymoney.command.VisualizeCommand;
 import wheresmymoney.exception.InvalidInputException;
 import wheresmymoney.exception.WheresMyMoneyException;
 
@@ -141,6 +142,8 @@ public class Parser {
             return new ListCommand(argumentsMap);
         case "stats":
             return new StatsCommand(argumentsMap);
+        case "visualize":
+            return new VisualizeCommand(argumentsMap);
         case "load":
             return new LoadCommand(argumentsMap);
         case "save":

--- a/src/main/java/wheresmymoney/RecurringExpense.java
+++ b/src/main/java/wheresmymoney/RecurringExpense.java
@@ -40,7 +40,7 @@ public class RecurringExpense extends Expense {
     public void setFrequency(String frequency) throws WheresMyMoneyException {
         if (frequency == null || frequency.isEmpty()) {
             throw new WheresMyMoneyException("Frequency should not be null");
-        } else if (!frequency.equals("daily") || !frequency.equals("weekly") || !frequency.equals("monthly")) {
+        } else if (!frequency.equals("daily") && !frequency.equals("weekly") && !frequency.equals("monthly")) {
             throw new WheresMyMoneyException("Frequency inputted is not \"daily\", \"weekly\" or \"monthly\"");
         }
         this.frequency = frequency;

--- a/src/main/java/wheresmymoney/category/CategoryTracker.java
+++ b/src/main/java/wheresmymoney/category/CategoryTracker.java
@@ -73,7 +73,7 @@ public class CategoryTracker {
     }
     
     /**
-     * Increases an existing category's running total by the given price.
+     * Increases an existing category's running total by the given price
      * or tracks a new category's expenditure details
      * <p>
      * If the category already exists, the current expenditure is increased by the given price.

--- a/src/main/java/wheresmymoney/command/AddCommand.java
+++ b/src/main/java/wheresmymoney/command/AddCommand.java
@@ -16,7 +16,8 @@ public class AddCommand extends Command {
     }
 
     /**
-     * Add a expense or recurring expense after prasing through arguments
+     * Add an expense or recurring expense after parsing through arguments
+     *
      * @param expenseList List of normal expenses
      * @param recurringExpenseList List of recurring expenses
      */

--- a/src/main/java/wheresmymoney/command/VisualizeCommand.java
+++ b/src/main/java/wheresmymoney/command/VisualizeCommand.java
@@ -1,6 +1,10 @@
 package wheresmymoney.command;
 
-import wheresmymoney.*;
+import wheresmymoney.Expense;
+import wheresmymoney.ExpenseList;
+import wheresmymoney.Parser;
+import wheresmymoney.RecurringExpenseList;
+import wheresmymoney.Ui;
 import wheresmymoney.category.CategoryFacade;
 import wheresmymoney.exception.WheresMyMoneyException;
 import wheresmymoney.visualizer.Visualizer;

--- a/src/main/java/wheresmymoney/command/VisualizeCommand.java
+++ b/src/main/java/wheresmymoney/command/VisualizeCommand.java
@@ -1,0 +1,56 @@
+package wheresmymoney.command;
+
+import wheresmymoney.*;
+import wheresmymoney.category.CategoryFacade;
+import wheresmymoney.exception.WheresMyMoneyException;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+public class VisualizeCommand extends Command {
+
+    public VisualizeCommand(HashMap<String, String> argumentsMap) {
+        super(argumentsMap);
+    }
+
+    /**
+     * Checks if given parameters are valid
+     *
+     * @author andrewnguyen4
+     * @return true if [category is null and at least one of (from, to) is not null],
+     *              or [category is not null and both (from, to) are null]
+     */
+    private boolean isValidParameters(String category, String from, String to) {
+        boolean hasNullCategory = (category == null);
+        boolean hasNullDate = (from == null && to == null);
+        return (hasNullCategory && !hasNullDate) || (!hasNullCategory && hasNullDate);
+    }
+
+    /**
+     * Get a list of expenses based on various filter metrics
+     *
+     * @author andrewnguyen4
+     * @param expenseList ExpenseList to be filtered by category, a start date and an end date
+     */
+    private ArrayList<Expense> getExpensesToVisualize(ExpenseList expenseList) throws WheresMyMoneyException {
+        String category = argumentsMap.get(Parser.ARGUMENT_CATEGORY);
+        String from = argumentsMap.get(Parser.ARGUMENT_FROM);
+        String to = argumentsMap.get(Parser.ARGUMENT_TO);
+        if (!isValidParameters(category, from, to)) {
+            throw new WheresMyMoneyException("Please provide either category or from/to date!");
+        }
+        return expenseList.listByFilter(category, from, to);
+    }
+
+
+    @Override
+    public void execute(ExpenseList expenseList, CategoryFacade categoryFacade,
+                        RecurringExpenseList recurringExpenseList) throws WheresMyMoneyException {
+        ArrayList<Expense> expensesToVisualize = getExpensesToVisualize(expenseList);
+        if (expensesToVisualize.isEmpty()) {
+            Ui.displayMessage("No matching expenses were found!");
+        }
+        // Execute by calling visualizer
+    }
+
+}

--- a/src/main/java/wheresmymoney/command/VisualizeCommand.java
+++ b/src/main/java/wheresmymoney/command/VisualizeCommand.java
@@ -42,7 +42,7 @@ public class VisualizeCommand extends Command {
 
         // Execute by calling visualizer
         Visualizer visualizer = new Visualizer(expensesToVisualize);
-        visualizer.drawChart();
+        visualizer.visualize();
     }
 
     private boolean hasNullDate(String from, String to) {

--- a/src/main/java/wheresmymoney/command/VisualizeCommand.java
+++ b/src/main/java/wheresmymoney/command/VisualizeCommand.java
@@ -3,6 +3,7 @@ package wheresmymoney.command;
 import wheresmymoney.*;
 import wheresmymoney.category.CategoryFacade;
 import wheresmymoney.exception.WheresMyMoneyException;
+import wheresmymoney.visualizer.Visualizer;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -11,19 +12,6 @@ public class VisualizeCommand extends Command {
 
     public VisualizeCommand(HashMap<String, String> argumentsMap) {
         super(argumentsMap);
-    }
-
-    /**
-     * Checks if given parameters are valid
-     *
-     * @author andrewnguyen4
-     * @return true if [category is null and at least one of (from, to) is not null],
-     *              or [category is not null and both (from, to) are null]
-     */
-    private boolean isValidParameters(String category, String from, String to) {
-        boolean hasNullCategory = (category == null);
-        boolean hasNullDate = (from == null && to == null);
-        return (hasNullCategory && !hasNullDate) || (!hasNullCategory && hasNullDate);
     }
 
     /**
@@ -42,15 +30,35 @@ public class VisualizeCommand extends Command {
         return expenseList.listByFilter(category, from, to);
     }
 
-
     @Override
     public void execute(ExpenseList expenseList, CategoryFacade categoryFacade,
                         RecurringExpenseList recurringExpenseList) throws WheresMyMoneyException {
         ArrayList<Expense> expensesToVisualize = getExpensesToVisualize(expenseList);
         if (expensesToVisualize.isEmpty()) {
             Ui.displayMessage("No matching expenses were found!");
+            return;
         }
+        assert (expensesToVisualize.size() > 0);
+
         // Execute by calling visualizer
+        Visualizer visualizer = new Visualizer(expensesToVisualize);
+        visualizer.drawChart();
     }
 
+    private boolean hasNullDate(String from, String to) {
+        return (from == null && to == null);
+    }
+
+    private boolean hasNullCategory(String category) {
+        return (category == null);
+    }
+    /**
+     * Checks if given parameters are valid
+     *
+     * @author andrewnguyen4
+     * @return true if exactly one of [category, (from/to)] is provided
+     */
+    private boolean isValidParameters(String category, String from, String to) {
+        return (hasNullCategory(category) ^ hasNullDate(from, to));
+    }
 }

--- a/src/main/java/wheresmymoney/visualizer/Visualizer.java
+++ b/src/main/java/wheresmymoney/visualizer/Visualizer.java
@@ -1,0 +1,165 @@
+package wheresmymoney.visualizer;
+
+import org.knowm.xchart.*;
+import org.knowm.xchart.style.Styler;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import wheresmymoney.DateUtils;
+import wheresmymoney.Expense;
+import wheresmymoney.ExpenseList;
+import wheresmymoney.exception.StorageException;
+import wheresmymoney.exception.WheresMyMoneyException;
+
+import javax.swing.*;
+
+import static java.util.stream.Collectors.groupingBy;
+
+public class Visualizer {
+    private ArrayList<Expense> expenses;
+    private LocalDate beginDate;
+    private LocalDate endDate;
+    private int dateRange;
+    private List<String> timeSeries = new ArrayList<>();
+    private final int DAY_NUMBER_LIMIT = 900;
+
+    public Visualizer(ArrayList<Expense> expenses) {
+        this.expenses = expenses;
+    }
+
+    private void getBeginDate() {
+        beginDate = expenses.get(0).getDateAdded();
+        for (Expense expense : expenses) {
+            if (expense.getDateAdded().isBefore(beginDate)) {
+                beginDate = expense.getDateAdded();
+            }
+        }
+    }
+
+    private void getEndDate(){
+        endDate = expenses.get(0).getDateAdded();
+        for (Expense expense : expenses) {
+            if (expense.getDateAdded().isAfter(endDate)) {
+                endDate = expense.getDateAdded();
+            }
+        }
+    }
+
+    private void getTimeRange() {
+        assert (beginDate != null && endDate != null);
+        dateRange = (int) ChronoUnit.DAYS.between(beginDate, endDate);
+    }
+
+    private List<String> createDateList () {
+        List<LocalDate> localDateList = beginDate.datesUntil(endDate.plusDays(1)).toList();
+        timeSeries = localDateList.stream()
+                .map(DateUtils::dateFormatToString).toList();
+        for (Expense e : expenses) {
+            assert (timeSeries.contains(DateUtils.dateFormatToString(e.getDateAdded())));
+        }
+        return timeSeries;
+    }
+
+    private List<String> createMonthList () { // Fix implementation!!
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MM-yyyy");
+
+        LocalDate current = beginDate.withDayOfMonth(1);
+        LocalDate end = endDate.withDayOfMonth(1);
+
+        while (!current.isAfter(end)) {
+            timeSeries.add(current.format(formatter));
+            current = current.plusMonths(1);
+        }
+        return timeSeries;
+    }
+
+    private HashMap<String, Float> groupPriceByDay () {
+        HashMap<String, Float> dateToExpenseMap = new HashMap<>();
+
+        // Initialize to give all dates a starting expenditure of 0
+        for (String date : timeSeries) {
+            dateToExpenseMap.put(date, 0.0f);
+        }
+
+        for (Expense e : expenses) {
+            String dateKey = DateUtils.dateFormatToString(e.getDateAdded());
+
+            // Increment the spending
+            dateToExpenseMap.put(dateKey, dateToExpenseMap.getOrDefault(dateKey, 0.0f) + e.getPrice());
+        }
+        return dateToExpenseMap;
+    }
+
+    private HashMap<String, Float> groupPriceByMonth () {
+        HashMap<String, Float> dateToExpenseMap = new HashMap<>();
+
+        for (String month : timeSeries) {
+            dateToExpenseMap.put(month, 0.0f);
+        }
+        for (Expense e : expenses) {
+            String dateKey = e.getDateAdded().getMonthValue() + "-" + e.getDateAdded().getYear();
+            if (e.getDateAdded().getMonthValue() < 10) { // One-digit month
+                dateKey = "0" + dateKey;
+            }
+
+            dateToExpenseMap.put(dateKey, dateToExpenseMap.getOrDefault(dateKey, 0.0f) + e.getPrice());
+        }
+        return dateToExpenseMap;
+    }
+
+
+    public void drawChart() throws WheresMyMoneyException {
+        // Calculate the time span in days
+        getBeginDate();
+        getEndDate();
+        getTimeRange();
+
+        if (dateRange > DAY_NUMBER_LIMIT) {
+            throw new WheresMyMoneyException("This date range is too large to display!");
+        }
+
+        // Group expenses by day or month based on time range
+        Map<String, Float> dateToExpenseMap;
+
+        if (dateRange <= 30) {  // For short durations (less than one month)
+            timeSeries = createDateList();
+            dateToExpenseMap = groupPriceByDay();
+        } else {
+            timeSeries = createMonthList();
+            dateToExpenseMap = groupPriceByMonth();
+        }
+
+        // Sort by date for clear plotting
+        List<Float> totalExpenses = timeSeries.stream().map(dateToExpenseMap::get).collect(Collectors.toList());
+
+        // Create chart
+        CategoryChart chart = new CategoryChartBuilder()
+                .width(800)
+                .height(600)
+                .title("Spending Chart")
+                .xAxisTitle(dateRange <= 30 ? "Day" : "Month")
+                .yAxisTitle("Total Spending")
+                .build();
+
+        // Customize chart
+        chart.getStyler().setLegendVisible(false);
+        chart.getStyler().setPlotGridLinesVisible(true);
+        // chart.getStyler().setDefaultSeriesRenderStyle(CategoryChart.SeriesRenderStyle.Bar);
+
+        // Add data to chart
+        chart.addSeries("Spending", timeSeries, totalExpenses);
+
+        // Display chart
+        SwingWrapper<CategoryChart> swingWrapper = new SwingWrapper<>(chart);
+        JFrame chartFrame = swingWrapper.displayChart();
+
+        // Set the default close operation to HIDE instead of EXIT
+        chartFrame.setDefaultCloseOperation(JFrame.HIDE_ON_CLOSE);
+    }
+}

--- a/src/main/java/wheresmymoney/visualizer/Visualizer.java
+++ b/src/main/java/wheresmymoney/visualizer/Visualizer.java
@@ -21,14 +21,15 @@ import javax.swing.JFrame;
 
 
 public class Visualizer {
+    private static final int DAY_VISUALIZER_THRESHOLD = 32;
+    private static final int MONTH_VISUALIZER_THRESHOLD = 1080;
     private ArrayList<Expense> expenses;
     private LocalDate beginDate;
     private LocalDate endDate;
     private int dateRange;
     private List<String> timeSeries = new ArrayList<>();
     private List<Float> totalExpenses = new ArrayList<>();
-    private static final int DAY_VISUALIZER_THRESHOLD = 32;
-    private static final int MONTH_VISUALIZER_THRESHOLD = 1080;
+
 
     public Visualizer(ArrayList<Expense> expenses) {
         this.expenses = expenses;

--- a/src/main/java/wheresmymoney/visualizer/Visualizer.java
+++ b/src/main/java/wheresmymoney/visualizer/Visualizer.java
@@ -27,8 +27,8 @@ public class Visualizer {
     private int dateRange;
     private List<String> timeSeries = new ArrayList<>();
     private List<Float> totalExpenses = new ArrayList<>();
-    private final int DAY_VISUALIZER_THRESHOLD = 32;
-    private final int MONTH_VISUALIZER_THRESHOLD = 1080;
+    private static final int DAY_VISUALIZER_THRESHOLD = 32;
+    private static final int MONTH_VISUALIZER_THRESHOLD = 1080;
 
     public Visualizer(ArrayList<Expense> expenses) {
         this.expenses = expenses;


### PR DESCRIPTION
Linked issue: #42 
Add `visualize` command.

The `visualize` command takes either `/category` or `/from /to` arguments to draw a bar graph of all qualifying expenses, grouped into their respective time partitions.
Current limit for `Visualizer` is 1080 days (~3 years) i.e. can visualize across a maximum time span of 1080 days.

Future improvements:
- Add year visualizer for large time spans
- Allow filtering by both category and time
- Better formatting & aesthetics